### PR TITLE
update models to incoporate set types & predicates

### DIFF
--- a/pickplace-secorolab-isaac.var.json
+++ b/pickplace-secorolab-isaac.var.json
@@ -13,27 +13,35 @@
     ],
     "@graph": [
         {
+            "@id": "var:obj-set", "@type": [ "bdd:ConstantSet", "bdd:Set" ],
+            "elements": [
+                "lab:obj-cube1", "lab:obj-cube2", "lab:obj-cube3", "lab:obj-cube4",
+                "lab:obj-ball1", "lab:obj-ball2", "lab:obj-ball3"
+            ]
+        },
+        {
             "@id": "var:comb-objects", "@type": "bdd:Combination",
             "repetition": "false",
-            "length": 1, "from": [
-                "lab:obj-ball1", "lab:obj-ball2", "lab:obj-ball3",
-                "lab:obj-cube1", "lab:obj-cube2", "lab:obj-cube3", "lab:obj-cube4"
-            ]
+            "length": 3, "from": "var:obj-set"
+        },
+        {
+            "@id": "var:ws-set", "@type": [ "bdd:ConstantSet", "bdd:Set" ],
+            "elements": [ "lab:ws-bin1", "lab:ws-bin2" ]
         },
         {
             "@id": "var:comb-workspaces", "@type": "bdd:Combination",
             "repetition": "false",
-            "length": 1, "from": [ "lab:ws-bin1", "lab:ws-bin2" ]
+            "length": 2, "from": "var:ws-set"
         },
         {
             "@id": "var:var-table", "@type": [ "bdd:TaskVariation", "bdd:TableVariation" ],
             "of-task": "tmpl:task-pickplace",
-            "variable-list": [ "tmpl:var-target-obj", "tmpl:var-pick-ws", "tmpl:var-place-ws" ],
+            "variable-list": [ "tmpl:var-target-obj", "tmpl:var-pick-ws", "tmpl:var-place-ws", "tmpl:var-agent" ],
             "rows": [
-                [ "lab:obj-bottle", "lab:ws-table", "lab:ws-shelf" ],
-                [ "lab:obj-ball1", "lab:ws-table", "lab:ws-shelf" ],
-                [ "lab:obj-bottle", "lab:ws-shelf", "lab:ws-table" ],
-                [ "lab:obj-ball1", "lab:ws-table", "lab:ws-table" ]
+                [ "lab:obj-bottle", "lab:ws-table", "lab:ws-shelf", "isaac-agn:panda" ],
+                [ "lab:obj-ball1", "lab:ws-table", "lab:ws-shelf", "isaac-agn:panda" ],
+                [ "lab:obj-bottle", "lab:ws-shelf", "lab:ws-table", "isaac-agn:panda" ],
+                [ "lab:obj-ball1", "lab:ws-table", "lab:ws-table", "isaac-agn:panda" ]
             ]
         },
         {

--- a/sorting-secorolab-isaac.var.json
+++ b/sorting-secorolab-isaac.var.json
@@ -13,17 +13,25 @@
     ],
     "@graph": [
         {
-            "@id": "var:comb-sort-objects", "@type": "bdd:Combination",
-            "repetition": "false",
-            "length": 3, "from": [
+            "@id": "var:obj-set", "@type": [ "bdd:ConstantSet", "bdd:Set" ],
+            "elements": [
                 "lab:obj-cube1", "lab:obj-cube2", "lab:obj-cube3", "lab:obj-cube4",
                 "lab:obj-ball1", "lab:obj-ball2", "lab:obj-ball3"
             ]
         },
         {
+            "@id": "var:comb-sort-objects", "@type": "bdd:Combination",
+            "repetition": "false",
+            "length": 3, "from": "var:obj-set"
+        },
+        {
+            "@id": "var:ws-set", "@type": [ "bdd:ConstantSet", "bdd:Set" ],
+            "elements": [ "lab:ws-bin1", "lab:ws-bin2" ]
+        },
+        {
             "@id": "var:comb-sort-workspaces", "@type": "bdd:Combination",
             "repetition": "false",
-            "length": 2, "from": [ "lab:ws-bin1", "lab:ws-bin2" ]
+            "length": 2, "from": "var:ws-set"
         },
         {
             "@id": "var:var-product", "@type": [ "bdd:TaskVariation", "bdd:CartesianProductVariation" ],

--- a/templates/sorting.tmpl.json
+++ b/templates/sorting.tmpl.json
@@ -30,8 +30,8 @@
         },
 
         { "@id": "tmpl:var-pick-ws", "@type": "bdd:ScenarioVariable" },
-        { "@id": "tmpl:var-sort-workspaces", "@type": "bdd:ScenarioVariable" },
-        { "@id": "tmpl:var-sort-objects", "@type": "bdd:ScenarioVariable" },
+        { "@id": "tmpl:var-sort-workspaces", "@type": [ "bdd:ScenarioVariable", "bdd:Set" ] },
+        { "@id": "tmpl:var-sort-objects", "@type": [ "bdd:ScenarioVariable", "bdd:Set" ] },
         { "@id": "tmpl:var-forall-obj", "@type": "bdd:ScenarioVariable" },
         { "@id": "tmpl:var-exists-ws", "@type": "bdd:ScenarioVariable" },
         { "@id": "tmpl:var-agent", "@type": "bdd:ScenarioVariable" },


### PR DESCRIPTION
- :Combination will now point to a :Set model instead of specifying its own container
- fix missing value for agent var in table example
- dependent on minhnh/metamodels-bdd#3