### PR TITLE
adapt to minhnh/metamodels-bdd#7, add query test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/execution/pickplace-secorolab-ros.obs.json
+++ b/execution/pickplace-secorolab-ros.obs.json
@@ -5,12 +5,16 @@
         "https://comp-rob2b.github.io/metamodels/geometry/spatial-relations.json",
         "https://comp-rob2b.github.io/metamodels/qudt.json",
         "https://secorolab.github.io/metamodels/acceptance-criteria/bdd/bdd.json",
+        "https://secorolab.github.io/metamodels/acceptance-criteria/bdd/behaviour.json",
         "https://secorolab.github.io/metamodels/acceptance-criteria/bdd/time.json",
         "https://secorolab.github.io/metamodels/acceptance-criteria/bdd/observation.json",
+        "https://secorolab.github.io/metamodels/acceptance-criteria/bdd/ros.json",
         "https://secorolab.github.io/metamodels/languages/python.json",
         {
             "tmpl": "https://secorolab.github.io/models/acceptance-criteria/bdd/templates/",
+            "var": "https://secorolab.github.io/models/acceptance-criteria/bdd/variants/pickplace-isaac/",
             "obs-ros": "https://secorolab.github.io/models/observation/ros/",
+            "bhv-ros": "https://secorolab.github.io/models/behaviour/ros/",
             "lab-geom": "https://secorolab.github.io/models/environments/secorolab/geometry/"
         }
     ],
@@ -45,26 +49,46 @@
                 "VectorXYZ"
             ],
             "unit": "M",
-            "message-type": "geometry_msgs/msg/PointStamped",
+            "type-name": "geometry_msgs/msg/PointStamped",
             "as-seen-by": "lab-geom:base-link-frame",
-            "topic-name": "/obj-bin1-position"
+            "channel-name": "/obj-bin1-position"
         },
         { "@id": "tmpl:flc-located-at-pick-ws", "horizon-seconds": 1.5 },
         { "@id": "tmpl:flc-located-at-place-ws", "horizon-seconds": 1.5 },
         {
-            "@id": "tmpl:flc-located-at-pick-ws", "@type": [ "ObservationPolicy", "ROSTopic" ],
-            "message-type": "bdd_ros2_interfaces/TrinaryStamped",
-            "topic-name": "/obs_policy/located_at_pick_ws"
+            "@id": "obs-ros:located-at-pick-topic", "@type": [ "ObservationPolicy", "ROSTopic" ],
+            "of-clause": "tmpl:flc-located-at-pick-ws",
+            "type-name": "bdd_ros2_interfaces/TrinaryStamped",
+            "channel-name": "/obs_policy/located_at_pick_ws"
         },
         {
-            "@id": "tmpl:flc-is-held", "@type": [ "ObservationPolicy", "ROSTopic" ],
-            "message-type": "bdd_ros2_interfaces/TrinaryStamped",
-            "topic-name": "/obs_policy/is_held"
+            "@id": "obs-ros:is-held-topic", "@type": [ "ObservationPolicy", "ROSTopic" ],
+            "of-clause": "tmpl:flc-is-held",
+            "type-name": "bdd_ros2_interfaces/TrinaryStamped",
+            "channel-name": "/obs_policy/is_held"
         },
         {
-            "@id": "tmpl:flc-located-at-place-ws", "@type": [ "ObservationPolicy", "ROSTopic" ],
-            "message-type": "bdd_ros2_interfaces/TrinaryStamped",
-            "topic-name": "/obs_policy/located_at_place_ws"
+            "@id": "obs-ros:located-at-place-topic", "@type": [ "ObservationPolicy", "ROSTopic" ],
+            "of-clause": "tmpl:flc-located-at-place-ws",
+            "type-name": "bdd_ros2_interfaces/TrinaryStamped",
+            "channel-name": "/obs_policy/located_at_place_ws"
+        },
+        {
+            "@id": "bhv-ros:pickplace-mockup", "@type": [ "BehaviourImplementation", "ROSAction" ],
+            "of-behaviour": "tmpl:bhv-pickplace",
+            "type-name": "bdd_ros2_interfaces/Behaviour", "channel-name": "/bdd/mockup_bhv_server"
+        },
+        {
+            "@id": "obs-ros:pickplace-ros", "@type": "bdd:ScenarioExecution",
+            "of-variant": [
+                "var:scr-var-panda-pickplace", "var:scr-var-panda-sorting", "var:scr-var-ur10-pickplace"
+            ],
+            "has-behaviour-impl": "bhv-ros:pickplace-mockup",
+            "has-policy": [
+                "obs-ros:located-at-pick-topic",
+                "obs-ros:is-held-topic",
+                "obs-ros:located-at-place-topic"
+            ]
         }
     ]
 }

--- a/queries/scenario-execution.rq
+++ b/queries/scenario-execution.rq
@@ -12,7 +12,7 @@ CONSTRUCT {
     ?bhvImpl a ?bhvImplType ;
         bhv:of-behaviour ?behaviour .
     ?obsPolicy a ?obsPolicyType ;
-        bhv:of-clause ?fluentClause .
+        bdd:of-clause ?fluentClause .
     ?behaviour a ?bhvType .
 }
 WHERE {

--- a/queries/scenario-execution.rq
+++ b/queries/scenario-execution.rq
@@ -1,21 +1,26 @@
 # SPDX-License-Identifier:  MPL-2.0
 PREFIX bhv: <https://secorolab.github.io/metamodels/behaviour#>
 PREFIX bdd: <https://secorolab.github.io/metamodels/acceptance-criteria/bdd#>
+PREFIX obs: <https://secorolab.github.io/metamodels/observation#>
 
 CONSTRUCT {
     ?scenarioExec a ?execType ;
         bdd:of-variant ?scenarioVar ;
         bdd:of-template ?scenarioTmpl ;
-        bdd:has-behaviour-impl ?bhvImpl .
+        bdd:has-behaviour-implementation ?bhvImpl ;
+        obs:has-policy ?obsPolicy .
     ?bhvImpl a ?bhvImplType ;
         bhv:of-behaviour ?behaviour .
+    ?obsPolicy a ?obsPolicyType ;
+        bhv:of-clause ?fluentClause .
     ?behaviour a ?bhvType .
 }
 WHERE {
     ?scenarioExec a bdd:ScenarioExecution ;
         a ?execType ;
         bdd:of-variant ?scenarioVar ;
-        bdd:has-behaviour-impl ?bhvImpl .
+        bdd:has-behaviour-implementation ?bhvImpl ;
+        obs:has-policy ?obsPolicy .
 
     ?scenarioVar a bdd:ScenarioVariant ;
         bdd:of-template ?scenarioTmpl .
@@ -27,6 +32,11 @@ WHERE {
         a bdd:BehaviourImplementation ;
         a ?bhvImplType ;
         bhv:of-behaviour ?behaviour .
+
+    ?obsPolicy
+        a obs:ObservationPolicy ;
+        a ?obsPolicyType ;
+        bdd:of-clause ?fluentClause .
 
     ?behaviour
         a bhv:Behaviour ;

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,43 @@
+import unittest
+from os.path import abspath, dirname, join
+from urllib.error import HTTPError
+from rdf_utils.caching import read_file_and_cache
+from rdf_utils.uri import URL_SECORO_M
+from rdflib import Dataset
+from rdf_utils.resolver import install_resolver
+
+
+CWD = abspath(dirname(__file__))
+ROOT_DIR = dirname(CWD)
+EXEC_RQ = join(ROOT_DIR, "queries", "scenario-execution.rq")
+SPEC_MODEL_URLS = {
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
+}
+EXEC_MODEL_URLS = {
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/execution/pickplace-secorolab-ros.obs.json": "json-ld",
+}
+
+class QueriesTest(unittest.TestCase):
+    def setUp(self):
+        install_resolver()
+
+    def test_scenario_execution_query(self):
+        graph = Dataset()
+        for url, fmt in SPEC_MODEL_URLS.items():
+            try:
+                graph.parse(url, format=fmt)
+            except HTTPError as e:
+                raise RuntimeError(f"HTTPError for URL '{url}': {e}")
+        for url, fmt in EXEC_MODEL_URLS.items():
+            try:
+                graph.parse(url, format=fmt)
+            except HTTPError as e:
+                raise RuntimeError(f"HTTPError for URL '{url}': {e}")
+
+        exec_rq_str = read_file_and_cache(EXEC_RQ)
+        q_result = graph.query(exec_rq_str)
+        assert (
+            q_result.type == "CONSTRUCT" and q_result.graph is not None
+        ), "ScenarioExecution query did not return a graph"
+        assert len(q_result.graph) > 0, "ScenarioExecution query returns an empty graph"

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -24,12 +24,7 @@ class QueriesTest(unittest.TestCase):
 
     def test_scenario_execution_query(self):
         graph = Dataset()
-        for url, fmt in SPEC_MODEL_URLS.items():
-            try:
-                graph.parse(url, format=fmt)
-            except HTTPError as e:
-                raise RuntimeError(f"HTTPError for URL '{url}': {e}")
-        for url, fmt in EXEC_MODEL_URLS.items():
+        for url, fmt in {**SPEC_MODEL_URLS, **EXEC_MODEL_URLS}.items():
             try:
                 graph.parse(url, format=fmt)
             except HTTPError as e:


### PR DESCRIPTION
* Change observation model to explicitly specify observation policies and behaviour implementation in scenario execution model. The new concepts are introduced in minhnh/metamodels-bdd#7.
* Add unit test for testing SPARQL queries, initially only testing scenario execution query. This requires [rdf-utils](https://github.com/minhnh/rdf-utils) as dependency.