### PR TITLE
Support variable scene elements

### DIFF
--- a/execution/pickplace-secorolab-ros.obs.json
+++ b/execution/pickplace-secorolab-ros.obs.json
@@ -13,6 +13,7 @@
         {
             "tmpl": "https://secorolab.github.io/models/acceptance-criteria/bdd/templates/",
             "var": "https://secorolab.github.io/models/acceptance-criteria/bdd/variants/pickplace-isaac/",
+            "var-grc": "https://secorolab.github.io/models/acceptance-criteria/bdd/variants/pickplace-grc/",
             "obs-ros": "https://secorolab.github.io/models/observation/ros/",
             "bhv-ros": "https://secorolab.github.io/models/behaviour/ros/",
             "lab-geom": "https://secorolab.github.io/models/environments/secorolab/geometry/"
@@ -81,7 +82,7 @@
         {
             "@id": "obs-ros:pickplace-ros", "@type": "bdd:ScenarioExecution",
             "of-variant": [
-                "var:scr-var-panda-pickplace", "var:scr-var-panda-sorting", "var:scr-var-ur10-pickplace"
+                "var:scr-var-pickplace", "var:scr-var-sorting", "var-grc:scr-var-grc"
             ],
             "has-behaviour-impl": "bhv-ros:pickplace-mockup",
             "has-policy": [

--- a/jinja/feature.jinja
+++ b/jinja/feature.jinja
@@ -1,33 +1,39 @@
 Feature: {{ data.name }}
-{%- if 'scene' in data %}
-  Background:
-    {%- if 'objects' in data.scene %}
-    Given a set of objects
-      | name |
-      {% for obj_name in data.scene.objects -%}
-        | {{ obj_name }} |
-      {% endfor %}
-    {%- endif -%}
-    {%- if 'workspaces' in data.scene %}
-    Given a set of workspaces
-      | name |
-      {% for ws_name in data.scene.workspaces -%}
-        | {{ ws_name }} |
-      {% endfor %}
-    {%- endif -%}
-    {%- if 'agents' in data.scene %}
-    Given a set of agents
-      | name |
-      {% for agn_name in data.scene.agents -%}
-        | {{ agn_name }} |
-      {% endfor %}
-    {%- endif %}
-    Given the scene is set up
-{%- endif %}
 
 {%- for scenario_data in data.criteria %}
 {% for var_data in scenario_data.variations %}
   Scenario: {{ var_data.name }}
+    {%- if 'scene' in var_data %}
+    {%- if 'objects' in var_data.scene %}
+    Given a set of objects
+      | name |
+      {% for obj_name in var_data.scene.objects -%}
+        | {{ obj_name }} |
+      {% endfor %}
+    {%- endif -%}
+    {%- if 'workspaces' in var_data.scene %}
+    Given a set of workspaces
+      | name |
+      {% for ws_name in var_data.scene.workspaces -%}
+        | {{ ws_name }} |
+      {% endfor %}
+    {%- endif -%}
+    {%- if 'agents' in var_data.scene %}
+    Given a set of agents
+      | name |
+      {% for agn_name in var_data.scene.agents -%}
+        | {{ agn_name }} |
+      {% endfor %}
+    {%- endif %}
+    {%- if 'elements' in var_data.scene %}
+    Given variable scene elements
+      | name |
+      {% for elem_name in var_data.scene.elements -%}
+        | {{ elem_name }} |
+      {% endfor %}
+    {%- endif %}
+    Given the scene is set up
+    {%- endif %}
     {% for clause in var_data.clauses%}
     {{ clause|safe }}{% endfor %}
 {% endfor %}

--- a/variations/pickplace-secorolab-isaac.var.json
+++ b/variations/pickplace-secorolab-isaac.var.json
@@ -45,7 +45,7 @@
             ]
         },
         {
-            "@id": "var:var-product-panda", "@type": [ "bdd:TaskVariation", "bdd:CartesianProductVariation" ],
+            "@id": "var:var-product", "@type": [ "bdd:TaskVariation", "bdd:CartesianProductVariation" ],
             "of-task": "tmpl:task-pickplace",
             "variable-list": [
                 "tmpl:var-target-obj", "tmpl:var-pick-ws", "tmpl:var-place-ws", "tmpl:var-agent"
@@ -54,46 +54,22 @@
                 "var:comb-objects",
                 [ "lab:ws-table" ],
                 "var:comb-workspaces",
-                [ "isaac-agn:panda" ]
+                [ "isaac-agn:panda", "isaac-agn:ur10" ]
             ]
         },
         {
-            "@id": "var:var-product-ur10", "@type": [ "bdd:TaskVariation", "bdd:CartesianProductVariation" ],
-            "of-task": "tmpl:task-pickplace",
-            "variable-list": [
-                "tmpl:var-target-obj", "tmpl:var-pick-ws", "tmpl:var-place-ws", "tmpl:var-agent"
-            ],
-            "of-sets": [
-                "var:comb-objects",
-                [ "lab:ws-table" ],
-                "var:comb-workspaces",
-                [ "isaac-agn:ur10" ]
-            ]
-        },
-        {
-            "@id": "var:scr-var-panda-pickplace", "@type": "bdd:ScenarioVariant",
+            "@id": "var:scr-var-pickplace", "@type": "bdd:ScenarioVariant",
             "of-template": "tmpl:tmpl-pickplace",
             "has-scene": [
                 "scene-lab:scn-pickplace-secorolab-objects",
-                "scene-lab:scn-pickplace-secorolab-workspaces",
-                "scene-isaac:scn-pickplace-isaac-panda"
+                "scene-lab:scn-pickplace-secorolab-workspaces"
             ],
-            "has-variation": "var:var-product-panda"
-        },
-        {
-            "@id": "var:scr-var-ur10-pickplace", "@type": "bdd:ScenarioVariant",
-            "of-template": "tmpl:tmpl-pickplace",
-            "has-scene": [
-                "scene-lab:scn-pickplace-secorolab-objects",
-                "scene-lab:scn-pickplace-secorolab-workspaces",
-                "scene-isaac:scn-pickplace-isaac-ur10"
-            ],
-            "has-variation": "var:var-product-ur10"
+            "has-variation": "var:var-product"
         },
         {
             "@id": "var:us-pickplace", "@type": "bdd:UserStory",
             "has-criteria": [
-                "var:scr-var-panda-pickplace"
+                "var:scr-var-pickplace"
             ]
         }
     ]

--- a/variations/sorting-secorolab-isaac.var.json
+++ b/variations/sorting-secorolab-isaac.var.json
@@ -43,23 +43,22 @@
                 "var:comb-sort-objects",
                 [ "lab:ws-table" ],
                 "var:comb-sort-workspaces",
-                [ "isaac-agn:panda" ]
+                [ "isaac-agn:panda", "isaac-agn:ur10" ]
             ]
         },
         {
-            "@id": "var:scr-var-panda-sorting", "@type": "bdd:ScenarioVariant",
+            "@id": "var:scr-var-sorting", "@type": "bdd:ScenarioVariant",
             "of-template": "tmpl:tmpl-sorting",
             "has-scene": [
                 "scene-lab:scn-sorting-secorolab-objects",
-                "scene-lab:scn-sorting-secorolab-workspaces",
-                "scene-isaac:scn-pickplace-isaac-panda"
+                "scene-lab:scn-sorting-secorolab-workspaces"
             ],
             "has-variation": "var:var-product"
         },
         {
             "@id": "var:us-sorting", "@type": "bdd:UserStory",
             "has-criteria": [
-                "var:scr-var-panda-sorting"
+                "var:scr-var-sorting"
             ]
         }
     ]


### PR DESCRIPTION
This relies on changes in minhnh/bdd-dsl#43 to add elements included via scenario variables and variations to the scene. Model changes include:

* Removing UR10- & Panda- specific scene and scenario variant specs.
* Updating Gherkin Jinja template so scene generation is repeated for each scenario variant insteand of in the Background section.

Minor: add GRC scenario variant to observation/execution model.